### PR TITLE
Use adaptive GridItem columns for responsive grids

### DIFF
--- a/dnd_app/dnd_app/CharacterSheetView.swift
+++ b/dnd_app/dnd_app/CharacterSheetView.swift
@@ -1420,13 +1420,13 @@ struct MainStatsView: View {
                 .fontWeight(.semibold)
                 .frame(maxWidth: .infinity, alignment: .leading)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 12) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: 12)], spacing: 12) {
                 StatCard(title: "КЗ", value: "\(character.armorClass)", color: .blue)
                 StatCard(title: "Инициатива", value: "\(character.initiative >= 0 ? "+" : "")\(character.initiative)", color: .green)
                 StatCard(title: "Скорость", value: "\(character.speed) фт", color: .purple)
             }
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 12) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
                 // Редактируемые хиты
                 Button(action: {
                     tempCurrentHP = character.currentHitPoints
@@ -1507,7 +1507,7 @@ struct AbilityScoresViewerView: View {
                 .fontWeight(.semibold)
                 .frame(maxWidth: .infinity, alignment: .leading)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 12) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
                 ForEach(abilities, id: \.0) { ability in
                     AbilityScoreViewerCard(
                         name: ability.0,
@@ -1720,7 +1720,7 @@ struct SkillsViewerView: View {
                 .fontWeight(.semibold)
                 .frame(maxWidth: .infinity, alignment: .leading)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 8) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                 ForEach(skills, id: \.0) { skill in
                     SkillViewerCard(
                         name: skill.0,
@@ -2035,7 +2035,7 @@ struct BasicInfoSection: View {
                 .font(.headline)
                 .fontWeight(.semibold)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 12) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Имя персонажа")
                         .font(.caption)
@@ -2120,7 +2120,7 @@ struct CombatStatsSection: View {
                 .font(.headline)
                 .fontWeight(.semibold)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 12) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Класс брони (КЗ)")
                         .font(.caption)
@@ -2275,7 +2275,7 @@ struct AbilityScoresSection: View {
                 .font(.headline)
                 .fontWeight(.semibold)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: 12) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: 12)], spacing: 12) {
                 ForEach(abilities, id: \.0) { ability in
                     AbilityScoreCard(
                         name: ability.0,
@@ -2402,7 +2402,7 @@ struct SkillsSection: View {
                 .font(.headline)
                 .fontWeight(.semibold)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 8) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                 ForEach(skills, id: \.0) { skill in
                     HStack {
                         Toggle("", isOn: binding(for: skill.1, in: \.skills))

--- a/dnd_app/dnd_app/CompendiumView.swift
+++ b/dnd_app/dnd_app/CompendiumView.swift
@@ -349,7 +349,7 @@ struct SpellFiltersView: View {
                                 .font(.headline)
                                 .fontWeight(.semibold)
                             
-                            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3), spacing: 8) {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: 8)], spacing: 8) {
                                 ForEach(0...9, id: \.self) { level in
                                     FilterButton(
                                         title: level == 0 ? "Заговоры" : "\(level) уровень",
@@ -367,7 +367,7 @@ struct SpellFiltersView: View {
                                 .font(.headline)
                                 .fontWeight(.semibold)
                             
-                            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 2), spacing: 8) {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                                 let schoolNames = [
                                     ("evocation", "Воплощение"),
                                     ("conjuration", "Вызов"),
@@ -396,7 +396,7 @@ struct SpellFiltersView: View {
                                 .font(.headline)
                                 .fontWeight(.semibold)
                             
-                            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 2), spacing: 8) {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                                 let classNames = [
                                     ("bard", "Бард"),
                                     ("sorcerer", "Волшебник"),
@@ -494,7 +494,7 @@ struct FeatFiltersView: View {
                                 .font(.headline)
                                 .fontWeight(.semibold)
                             
-                            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 2), spacing: 8) {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                                 ForEach(store.availableFeatCategories, id: \.self) { category in
                                     FilterButton(
                                         title: category,

--- a/dnd_app/dnd_app/NotesView.swift
+++ b/dnd_app/dnd_app/NotesView.swift
@@ -684,7 +684,7 @@ struct AddNoteView: View {
                                 .fontWeight(.semibold)
                                 .foregroundColor(.primary)
                             
-                            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: 12) {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
                                 ForEach(NoteCategory.allCases, id: \.self) { category in
                                     Button(action: { selectedCategory = category }) {
                                         VStack(spacing: 8) {

--- a/dnd_app/dnd_app/SpellsView.swift
+++ b/dnd_app/dnd_app/SpellsView.swift
@@ -269,7 +269,7 @@ struct AdvancedFiltersView: View {
                             .font(.headline)
                             .fontWeight(.semibold)
                         
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3), spacing: 8) {
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: 8)], spacing: 8) {
                             ForEach(0...9, id: \.self) { level in
                                 FilterButton(
                                     title: level == 0 ? "Заговоры" : "\(level) уровень",
@@ -287,7 +287,7 @@ struct AdvancedFiltersView: View {
                             .font(.headline)
                             .fontWeight(.semibold)
                         
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 2), spacing: 8) {
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                             let schoolNames = [
                                 ("evocation", "Воплощение"),
                                 ("conjuration", "Вызов"),
@@ -316,7 +316,7 @@ struct AdvancedFiltersView: View {
                             .font(.headline)
                             .fontWeight(.semibold)
                         
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 2), spacing: 8) {
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                             let classNames = [
                                 ("bard", "Бард"),
                                 ("sorcerer", "Волшебник"),


### PR DESCRIPTION
## Summary
- replace fixed grid column counts with adaptive layouts
- allow grid columns to grow or shrink based on available width

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a03d792a908329b46a223026582470