### PR TITLE
Use adaptive layout for icons and views

### DIFF
--- a/dnd_app/dnd_app/CharacterSheetView.swift
+++ b/dnd_app/dnd_app/CharacterSheetView.swift
@@ -874,23 +874,22 @@ struct ModernStatBadge: View {
     var body: some View {
         HStack(spacing: 12) {
             // Иконка с градиентным фоном
-            ZStack {
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: [color, color.opacity(0.8)],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundColor(.white)
+                .padding(8)
+                .background(
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                colors: [color, color.opacity(0.8)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
                         )
-                    )
-                    .frame(width: 36, height: 36)
-                    .shadow(color: color.opacity(0.3), radius: 4, x: 0, y: 2)
-                
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(.white)
-            }
-            
+                        .shadow(color: color.opacity(0.3), radius: 4, x: 0, y: 2)
+                )
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.caption)

--- a/dnd_app/dnd_app/CompendiumView.swift
+++ b/dnd_app/dnd_app/CompendiumView.swift
@@ -26,9 +26,8 @@ struct CompendiumView: View {
                             HStack {
                                 Image(systemName: "wand.and.stars")
                                     .foregroundColor(.purple)
-                                    .font(.title2)
-                                    .frame(width: 30)
-                                
+                                    .font(.title)
+
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text("Заклинания")
                                         .font(.headline)
@@ -37,25 +36,25 @@ struct CompendiumView: View {
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
-                                
+
                                 Spacer()
-                                
+
                                 Image(systemName: "chevron.right")
                                     .foregroundColor(.secondary)
                                     .font(.caption)
                             }
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, 8)
                         }
                         .listRowBackground(Color(.systemBackground))
                         .listRowSeparator(.hidden)
-                        
+
                         NavigationLink(destination: BackgroundsTabView(store: store, favorites: favorites, themeManager: themeManager)) {
                             HStack {
                                 Image(systemName: "person.3.sequence")
                                     .foregroundColor(.blue)
-                                    .font(.title2)
-                                    .frame(width: 30)
-                                
+                                    .font(.title)
+
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text("Предыстории")
                                         .font(.headline)
@@ -64,25 +63,25 @@ struct CompendiumView: View {
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
-                                
+
                                 Spacer()
-                                
+
                                 Image(systemName: "chevron.right")
                                     .foregroundColor(.secondary)
                                     .font(.caption)
                             }
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, 8)
                         }
                         .listRowBackground(Color(.systemBackground))
                         .listRowSeparator(.hidden)
-                        
+
                         NavigationLink(destination: FeatsTabView(store: store, favorites: favorites, themeManager: themeManager)) {
                             HStack {
                                 Image(systemName: "star.circle")
                                     .foregroundColor(.orange)
-                                    .font(.title2)
-                                    .frame(width: 30)
-                                
+                                    .font(.title)
+
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text("Черты")
                                         .font(.headline)
@@ -91,25 +90,25 @@ struct CompendiumView: View {
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
-                                
+
                                 Spacer()
-                                
+
                                 Image(systemName: "chevron.right")
                                     .foregroundColor(.secondary)
                                     .font(.caption)
                             }
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, 8)
                         }
                         .listRowBackground(Color(.systemBackground))
                         .listRowSeparator(.hidden)
-                        
+
                         NavigationLink(destination: BestiaryTabView()) {
                             HStack {
                                 Image(systemName: "pawprint.circle")
                                     .foregroundColor(.green)
-                                    .font(.title2)
-                                    .frame(width: 30)
-                                
+                                    .font(.title)
+
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text("Бестиарий")
                                         .font(.headline)
@@ -118,25 +117,25 @@ struct CompendiumView: View {
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
-                                
+
                                 Spacer()
-                                
+
                                 Image(systemName: "chevron.right")
                                     .foregroundColor(.secondary)
                                     .font(.caption)
                             }
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, 8)
                         }
                         .listRowBackground(Color(.systemBackground))
                         .listRowSeparator(.hidden)
-                        
+
                         NavigationLink(destination: FavoritesTabView(store: store, favorites: favorites, themeManager: themeManager)) {
                             HStack {
                                 Image(systemName: "heart.circle")
                                     .foregroundColor(.red)
-                                    .font(.title2)
-                                    .frame(width: 30)
-                                
+                                    .font(.title)
+
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text("Избранное")
                                         .font(.headline)
@@ -145,13 +144,14 @@ struct CompendiumView: View {
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
-                                
+
                                 Spacer()
-                                
+
                                 Image(systemName: "chevron.right")
                                     .foregroundColor(.secondary)
                                     .font(.caption)
                             }
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, 8)
                         }
                         .listRowBackground(Color(.systemBackground))

--- a/dnd_app/dnd_app/JSONQuoteView.swift
+++ b/dnd_app/dnd_app/JSONQuoteView.swift
@@ -327,14 +327,14 @@ struct JSONCategoryCard: View {
         HStack(spacing: 16) {
             // Иконка категории
             Image(systemName: "quote.bubble.fill")
-                .font(.title2)
+                .font(.title)
                 .foregroundColor(.orange)
-                .frame(width: 40, height: 40)
+                .padding(8)
                 .background(
                     Circle()
                         .fill(Color.orange.opacity(0.1))
                 )
-            
+
             // Информация о категории
             VStack(alignment: .leading, spacing: 4) {
                 Text(category.name)
@@ -349,6 +349,7 @@ struct JSONCategoryCard: View {
             
             Spacer()
         }
+        .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
         .padding(20)
         .background(
             RoundedRectangle(cornerRadius: 16)


### PR DESCRIPTION
## Summary
- Replace fixed frame widths in Compendium list rows with flexible `frame(minWidth:maxWidth:)`
- Scale system icons via `.font(.title)` and remove hard size constraints
- Refactor stat badge and quote category card to rely on padding/background instead of fixed frames

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a03d83a8ac8329a6b7edb23c369dbc