### PR TITLE
Use asset catalog for background color and dynamic theme

### DIFF
--- a/dnd_app/dnd_app/Assets.xcassets/BackgroundColor.colorset/Contents.json
+++ b/dnd_app/dnd_app/Assets.xcassets/BackgroundColor.colorset/Contents.json
@@ -1,0 +1,44 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.988",
+          "green" : "0.933",
+          "blue" : "0.855",
+          "alpha" : "1.000"
+        }
+      },
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ]
+    },
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.110",
+          "green" : "0.110",
+          "blue" : "0.118",
+          "alpha" : "1.000"
+        }
+      },
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ]
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/dnd_app/dnd_app/CharacterSheetView.swift
+++ b/dnd_app/dnd_app/CharacterSheetView.swift
@@ -735,9 +735,9 @@ struct CharacterSheetView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -1028,7 +1028,7 @@ struct CharacterImportView: View {
                 Spacer()
             }
             .padding()
-            .background(Color(hex: "#fceeda"))
+            .background(Color("BackgroundColor"))
             .navigationTitle("Импорт")
             .navigationBarTitleDisplayMode(.inline)
             .alert(isSuccess ? "Успех!" : "Ошибка", isPresented: $showingAlert) {
@@ -1352,8 +1352,8 @@ struct CharacterViewerView: View {
             .background(
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9)
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9)
                     ],
                     startPoint: .top,
                     endPoint: .bottom
@@ -1986,7 +1986,7 @@ struct CharacterEditorView: View {
                 }
                 .padding()
             }
-            .background(Color(hex: "#fceeda"))
+            .background(Color("BackgroundColor"))
             .navigationTitle(character == nil ? "Новый персонаж" : "Редактирование")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/dnd_app/dnd_app/CommonStyles.swift
+++ b/dnd_app/dnd_app/CommonStyles.swift
@@ -213,7 +213,7 @@ struct CommonColors {
     static let success = Color.green
     static let warning = Color.yellow
     static let error = Color.red
-    static let background = Color(hex: "#fceeda")
+    static let background = Color("BackgroundColor")
     static let cardBackground = Color(.systemBackground)
     static let textPrimary = Color(.label)
     static let textSecondary = Color(.secondaryLabel)

--- a/dnd_app/dnd_app/CompendiumView.swift
+++ b/dnd_app/dnd_app/CompendiumView.swift
@@ -10,9 +10,9 @@ struct CompendiumView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -338,7 +338,7 @@ struct SpellFiltersView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color(hex: "#fceeda")
+                Color("BackgroundColor")
                     .ignoresSafeArea()
                 
                 ScrollView {
@@ -483,7 +483,7 @@ struct FeatFiltersView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color(hex: "#fceeda")
+                Color("BackgroundColor")
                     .ignoresSafeArea()
                 
                 ScrollView {
@@ -575,9 +575,9 @@ struct FavoritesTabView: View {
         ZStack {
             LinearGradient(
                 colors: [
-                    Color(hex: "#fceeda"),
-                    Color(hex: "#fceeda").opacity(0.9),
-                    Color(hex: "#fceeda")
+                    Color("BackgroundColor"),
+                    Color("BackgroundColor").opacity(0.9),
+                    Color("BackgroundColor")
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing

--- a/dnd_app/dnd_app/ContentView.swift
+++ b/dnd_app/dnd_app/ContentView.swift
@@ -1,33 +1,5 @@
 import SwiftUI
 
-// MARK: - Color Extension for Hex Support  
-extension Color {
-    init(hex: String) {
-        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        var int: UInt64 = 0
-        Scanner(string: hex).scanHexInt64(&int)
-        let a, r, g, b: UInt64
-        switch hex.count {
-        case 3: // RGB (12-bit)
-            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-        case 6: // RGB (24-bit)
-            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8: // ARGB (32-bit)
-            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
-        default:
-            (a, r, g, b) = (1, 1, 1, 0)
-        }
-
-        self.init(
-            .sRGB,
-            red: Double(r) / 255,
-            green: Double(g) / 255,
-            blue:  Double(b) / 255,
-            opacity: Double(a) / 255
-        )
-    }
-}
-
 struct ContentView: View {
     @StateObject private var manager = QuoteManager()
     @StateObject private var spells = CompendiumStore()
@@ -69,9 +41,9 @@ struct ContentView: View {
         .background(
             LinearGradient(
                 colors: [
-                    Color(hex: "#fceeda"),
-                    Color(hex: "#fceeda").opacity(0.8),
-                    Color(hex: "#fceeda")
+                    Color("BackgroundColor"),
+                    Color("BackgroundColor").opacity(0.8),
+                    Color("BackgroundColor")
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing

--- a/dnd_app/dnd_app/JSONQuoteView.swift
+++ b/dnd_app/dnd_app/JSONQuoteView.swift
@@ -254,9 +254,9 @@ struct JSONQuoteManagementView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -369,9 +369,9 @@ struct JSONCategoryQuotesView: View {
         ZStack {
             LinearGradient(
                 colors: [
-                    Color(hex: "#fceeda"),
-                    Color(hex: "#fceeda").opacity(0.9),
-                    Color(hex: "#fceeda")
+                    Color("BackgroundColor"),
+                    Color("BackgroundColor").opacity(0.9),
+                    Color("BackgroundColor")
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing

--- a/dnd_app/dnd_app/NotesView.swift
+++ b/dnd_app/dnd_app/NotesView.swift
@@ -144,9 +144,9 @@ struct NotesView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -618,9 +618,9 @@ struct AddNoteView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing

--- a/dnd_app/dnd_app/RelationshipView.swift
+++ b/dnd_app/dnd_app/RelationshipView.swift
@@ -103,7 +103,7 @@ struct RelationshipView: View {
         NavigationStack {
             ZStack {
                 // Фон #fceeda
-                Color(hex: "#fceeda")
+                Color("BackgroundColor")
                 .ignoresSafeArea()
 
                 Group {
@@ -521,7 +521,7 @@ struct AddPersonView: View {
         NavigationStack {
             ZStack {
                 // Фон #fceeda
-                Color(hex: "#fceeda")
+                Color("BackgroundColor")
                     .ignoresSafeArea()
                 
                 ScrollView {

--- a/dnd_app/dnd_app/SettingsView.swift
+++ b/dnd_app/dnd_app/SettingsView.swift
@@ -11,9 +11,9 @@ struct SettingsView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -65,11 +65,11 @@ struct SettingsView: View {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("Тема приложения")
                                     .font(.headline)
-                                    .foregroundColor(ThemeManager.adaptiveTextColor(for: themeManager.isDarkMode))
+                                    .foregroundColor(ThemeManager.adaptiveTextColor(for: themeManager.preferredColorScheme))
                                 
                                 Text(themeManager.isDarkMode ? "Темная тема" : "Светлая тема")
                                     .font(.caption)
-                                    .foregroundColor(ThemeManager.adaptiveSecondaryTextColor(for: themeManager.isDarkMode))
+                                    .foregroundColor(ThemeManager.adaptiveSecondaryTextColor(for: themeManager.preferredColorScheme))
                             }
                             
                             Spacer()
@@ -358,9 +358,9 @@ struct QuoteManagerView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -951,9 +951,9 @@ struct ModernAddQuoteView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -1053,9 +1053,9 @@ struct ModernEditCategoryView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -1192,7 +1192,7 @@ struct QuoteEditorAddView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color(hex: "#fceeda")
+                Color("BackgroundColor")
                     .ignoresSafeArea()
                 
                 VStack(spacing: 24) {

--- a/dnd_app/dnd_app/SpellsView.swift
+++ b/dnd_app/dnd_app/SpellsView.swift
@@ -16,9 +16,9 @@ struct SpellsView: View {
         ZStack {
             LinearGradient(
                 colors: [
-                    Color(hex: "#fceeda"),
-                    Color(hex: "#fceeda").opacity(0.9),
-                    Color(hex: "#fceeda")
+                    Color("BackgroundColor"),
+                    Color("BackgroundColor").opacity(0.9),
+                    Color("BackgroundColor")
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
@@ -119,9 +119,9 @@ struct SpellSearchView: View {
             ZStack {
                 LinearGradient(
                     colors: [
-                        Color(hex: "#fceeda"),
-                        Color(hex: "#fceeda").opacity(0.9),
-                        Color(hex: "#fceeda")
+                        Color("BackgroundColor"),
+                        Color("BackgroundColor").opacity(0.9),
+                        Color("BackgroundColor")
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
@@ -258,7 +258,7 @@ struct AdvancedFiltersView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color(hex: "#fceeda")
+                Color("BackgroundColor")
                     .ignoresSafeArea()
                 
                 ScrollView {

--- a/dnd_app/dnd_app/ThemeManager.swift
+++ b/dnd_app/dnd_app/ThemeManager.swift
@@ -19,8 +19,8 @@ final class ThemeManager: ObservableObject {
         return isDarkMode ? .dark : .light
     }
     
-    // Цвета для светлой темы
-    static let lightBackgroundColor = Color(hex: "#fceeda")
+    // Базовый цвет из ассетов
+    static let backgroundColor = Color("BackgroundColor")
     
     // Цвета для темной темы  
     static let darkBackgroundGradient = LinearGradient(
@@ -34,28 +34,28 @@ final class ThemeManager: ObservableObject {
     )
     
     // Адаптивные цвета
-    static func adaptiveBackground(for isDark: Bool) -> AnyView {
-        if isDark {
+    static func adaptiveBackground(for colorScheme: ColorScheme?) -> AnyView {
+        if colorScheme == .dark {
             return AnyView(darkBackgroundGradient)
         } else {
-            return AnyView(lightBackgroundColor)
+            return AnyView(backgroundColor)
         }
     }
-    
-    static func adaptiveCardBackground(for isDark: Bool) -> Color {
-        return isDark ? Color(.systemGray6) : Color(.systemBackground)
+
+    static func adaptiveCardBackground(for colorScheme: ColorScheme?) -> Color {
+        colorScheme == .dark ? Color(.systemGray6) : Color(.systemBackground)
     }
-    
-    static func adaptiveTextColor(for isDark: Bool) -> Color {
-        return isDark ? .white : .primary
+
+    static func adaptiveTextColor(for colorScheme: ColorScheme?) -> Color {
+        colorScheme == .dark ? .white : .primary
     }
-    
-    static func adaptiveSecondaryTextColor(for isDark: Bool) -> Color {
-        return isDark ? .gray : .secondary
+
+    static func adaptiveSecondaryTextColor(for colorScheme: ColorScheme?) -> Color {
+        colorScheme == .dark ? .gray : .secondary
     }
-    
-    static func adaptiveBorderColor(for isDark: Bool) -> Color {
-        return isDark ? Color(.systemGray4) : Color(.systemGray5)
+
+    static func adaptiveBorderColor(for colorScheme: ColorScheme?) -> Color {
+        colorScheme == .dark ? Color(.systemGray4) : Color(.systemGray5)
     }
     
     // MARK: - Cache Management


### PR DESCRIPTION
## Summary
- add `BackgroundColor` asset with light and dark variants
- replace `Color(hex:)` usages with `Color("BackgroundColor")`
- update `ThemeManager` to derive palette from `preferredColorScheme`

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a03d7480548329a314a5b25ff72b21