### PR TITLE
Bridge cached Data to NSData without copy

### DIFF
--- a/dnd_app/dnd_app/CacheManager.swift
+++ b/dnd_app/dnd_app/CacheManager.swift
@@ -81,7 +81,7 @@ final class CacheManager: ObservableObject {
     // MARK: - Data Caching
     func cacheData(_ data: Data, for key: String) {
         let nsKey = NSString(string: key)
-        let nsData = NSData(data: data)
+        let nsData = data as NSData
         dataCache.setObject(nsData, forKey: nsKey)
         updateStats()
     }

--- a/dnd_app/tabaxiTests/CacheManagerDataTests.swift
+++ b/dnd_app/tabaxiTests/CacheManagerDataTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import tabaxi
+
+final class CacheManagerDataTests: XCTestCase {
+    func testCacheDataRetrieval() {
+        let cache = CacheManager.shared
+        let key = "test_cache_data_retrieval"
+        let originalData = "hello world".data(using: .utf8)!
+        cache.cacheData(originalData, for: key)
+        let retrieved = cache.getData(for: key)
+        XCTAssertEqual(retrieved, originalData)
+    }
+}


### PR DESCRIPTION
## Summary
- Avoid unnecessary Data copying in CacheManager by bridging to NSData
- Add unit test ensuring Data cache retrieval returns original data

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift - <<'SWIFT' ... SWIFT`

------
https://chatgpt.com/codex/tasks/task_e_68a03c9448d88329b2715fe8e56d4d38