### PR TITLE
Adopt dynamic text styles for accessibility

### DIFF
--- a/dnd_app/dnd_app/CharacterSheetView.swift
+++ b/dnd_app/dnd_app/CharacterSheetView.swift
@@ -774,7 +774,8 @@ struct CharacterSheetView: View {
                     if filteredCharacters.isEmpty {
                         VStack(spacing: 20) {
                             Image(systemName: "person.text.rectangle")
-                                .font(.system(size: 60))
+                                .font(.title2)
+                                .dynamicTypeSize(.medium ... .xxLarge)
                                 .foregroundColor(.orange)
                             
                             Text("Нет персонажей")
@@ -887,7 +888,8 @@ struct ModernStatBadge: View {
                     .shadow(color: color.opacity(0.3), radius: 4, x: 0, y: 2)
                 
                 Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
+                    .font(.headline)
+                    .dynamicTypeSize(.small ... .xLarge)
                     .foregroundColor(.white)
             }
             
@@ -936,7 +938,8 @@ struct CharacterImportView: View {
                 // Заголовок
                 VStack(spacing: 8) {
                     Image(systemName: "doc.badge.plus")
-                        .font(.system(size: 50))
+                        .font(.title2)
+                        .dynamicTypeSize(.medium ... .xxLarge)
                         .foregroundColor(.orange)
                     
                     Text("Импорт персонажа")
@@ -1150,7 +1153,8 @@ struct CharacterCard: View {
                     .frame(width: 50, height: 50)
                     .overlay(
                         Image(systemName: "person.fill")
-                            .font(.system(size: 24))
+                            .font(.headline)
+                            .dynamicTypeSize(.small ... .xLarge)
                             .foregroundColor(.white)
                     )
                 

--- a/dnd_app/dnd_app/CommonStyles.swift
+++ b/dnd_app/dnd_app/CommonStyles.swift
@@ -127,7 +127,8 @@ struct CommonButton: View {
             HStack(spacing: 8) {
                 if let icon = icon {
                     Image(systemName: icon)
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.headline)
+                        .dynamicTypeSize(.small ... .xLarge)
                 }
                 Text(title)
             }
@@ -152,7 +153,8 @@ struct CommonSecondaryButton: View {
             HStack(spacing: 8) {
                 if let icon = icon {
                     Image(systemName: icon)
-                        .font(.system(size: 16, weight: .medium))
+                        .font(.headline)
+                        .dynamicTypeSize(.small ... .xLarge)
                 }
                 Text(title)
             }
@@ -187,7 +189,8 @@ struct CommonSectionHeader: View {
         HStack(spacing: 8) {
             if let icon = icon {
                 Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
+                    .font(.headline)
+                    .dynamicTypeSize(.small ... .xLarge)
                     .foregroundColor(.orange)
             }
             Text(title)

--- a/dnd_app/dnd_app/CompendiumView.swift
+++ b/dnd_app/dnd_app/CompendiumView.swift
@@ -311,7 +311,8 @@ struct BestiaryTabView: View {
             Spacer()
             
             Image(systemName: "pawprint.circle.fill")
-                .font(.system(size: 80))
+                .font(.title2)
+                .dynamicTypeSize(.medium ... .xxLarge)
                 .foregroundColor(.orange)
             
             Text("Бестиарий")
@@ -590,7 +591,8 @@ struct FavoritesTabView: View {
                         Spacer()
                         
                         Image(systemName: "heart.slash")
-                            .font(.system(size: 60))
+                            .font(.title2)
+                            .dynamicTypeSize(.medium ... .xxLarge)
                             .foregroundColor(.orange)
                         
                         Text("Нет избранного")

--- a/dnd_app/dnd_app/JSONQuoteView.swift
+++ b/dnd_app/dnd_app/JSONQuoteView.swift
@@ -383,7 +383,8 @@ struct JSONCategoryQuotesView: View {
                     // Пустое состояние
                     VStack(spacing: 20) {
                         Image(systemName: "quote.bubble")
-                            .font(.system(size: 60))
+                            .font(.title2)
+                            .dynamicTypeSize(.medium ... .xxLarge)
                             .foregroundColor(.orange)
                         
                         Text("Нет цитат в категории")
@@ -546,7 +547,8 @@ struct JSONCategoryButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 14, weight: .medium))
+                .font(.headline)
+                .dynamicTypeSize(.small ... .xLarge)
                 .foregroundColor(isSelected ? .white : .primary)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)

--- a/dnd_app/dnd_app/NotesView.swift
+++ b/dnd_app/dnd_app/NotesView.swift
@@ -240,7 +240,8 @@ struct NotesView: View {
                     if filteredNotes.isEmpty {
                         VStack(spacing: 20) {
                             Image(systemName: "note.text")
-                                .font(.system(size: 60))
+                                .font(.title2)
+                                .dynamicTypeSize(.medium ... .xxLarge)
                                 .foregroundColor(.orange)
                             
                             Text("Нет заметок")

--- a/dnd_app/dnd_app/RelationshipView.swift
+++ b/dnd_app/dnd_app/RelationshipView.swift
@@ -110,11 +110,12 @@ struct RelationshipView: View {
                     if store.people.isEmpty {
                         VStack(spacing: 30) {
                             Spacer()
-                            
+
                             Image(systemName: "person.3.fill")
-                                .font(.system(size: 80))
+                                .font(.title2)
+                                .dynamicTypeSize(.medium ... .xxLarge)
                                 .foregroundColor(.gray)
-                            
+
                                 Text("Нет персонажей")
                                 .font(.title2)
                                 .fontWeight(.semibold)

--- a/dnd_app/dnd_app/SettingsView.swift
+++ b/dnd_app/dnd_app/SettingsView.swift
@@ -37,7 +37,8 @@ struct SettingsView: View {
                                 .blur(radius: 20)
                             
                             Image(systemName: "gearshape.fill")
-                                .font(.system(size: 50))
+                                .font(.title2)
+                                .dynamicTypeSize(.medium ... .xxLarge)
                                 .foregroundColor(.orange)
                                 .shadow(color: .orange.opacity(0.4), radius: 8, x: 0, y: 4)
                         }
@@ -383,7 +384,8 @@ struct QuoteManagerView: View {
                                 .blur(radius: 15)
                             
                             Image(systemName: "quote.bubble.fill")
-                                .font(.system(size: 35))
+                                .font(.title2)
+                                .dynamicTypeSize(.medium ... .xxLarge)
                                 .foregroundColor(.orange)
                                 .shadow(color: .orange.opacity(0.4), radius: 6, x: 0, y: 3)
                         }

--- a/dnd_app/dnd_app/SpellsView.swift
+++ b/dnd_app/dnd_app/SpellsView.swift
@@ -421,7 +421,8 @@ struct AllSpellsTab: View {
                     Spacer()
                     
                     Image(systemName: "heart.slash")
-                        .font(.system(size: 60))
+                        .font(.title2)
+                        .dynamicTypeSize(.medium ... .xxLarge)
                         .foregroundColor(.orange)
                     
                     Text("Нет избранного")


### PR DESCRIPTION
## Summary
- replace hard-coded fonts with `.title2`/`.headline`
- constrain view scaling using `dynamicTypeSize`

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a03d8836788329b168b47623157000