### PR TITLE
Separate favorites caches for spells, feats, and backgrounds

### DIFF
--- a/dnd_app/dnd_app/CacheManager.swift
+++ b/dnd_app/dnd_app/CacheManager.swift
@@ -46,6 +46,9 @@ final class CacheManager: ObservableObject {
         case featFilters = "feat_filters_cache"
         case themeSettings = "theme_settings_cache"
         case favorites = "favorites_cache"
+        case favoritesSpells = "favorites_spells"
+        case favoritesFeats = "favorites_feats"
+        case favoritesBackgrounds = "favorites_backgrounds"
     }
     
     // MARK: - Cache Statistics
@@ -391,5 +394,29 @@ extension CacheManager {
     
     func getCachedFavorites() -> [String]? {
         return getCodable(for: CacheKey.favorites.rawValue)
+    }
+
+    func cacheFavoriteSpells(_ favorites: [String]) {
+        cacheCodable(favorites, for: CacheKey.favoritesSpells.rawValue)
+    }
+
+    func getCachedFavoriteSpells() -> [String]? {
+        return getCodable(for: CacheKey.favoritesSpells.rawValue)
+    }
+
+    func cacheFavoriteFeats(_ favorites: [String]) {
+        cacheCodable(favorites, for: CacheKey.favoritesFeats.rawValue)
+    }
+
+    func getCachedFavoriteFeats() -> [String]? {
+        return getCodable(for: CacheKey.favoritesFeats.rawValue)
+    }
+
+    func cacheFavoriteBackgrounds(_ favorites: [String]) {
+        cacheCodable(favorites, for: CacheKey.favoritesBackgrounds.rawValue)
+    }
+
+    func getCachedFavoriteBackgrounds() -> [String]? {
+        return getCodable(for: CacheKey.favoritesBackgrounds.rawValue)
     }
 }

--- a/dnd_app/dnd_app/FavoriteSpellsManager.swift
+++ b/dnd_app/dnd_app/FavoriteSpellsManager.swift
@@ -182,42 +182,47 @@ final class FavoriteSpellsManager: ObservableObject {
     private func saveSpells() {
         UserDefaults.standard.set(Array(favoriteSpells), forKey: spellsStorageKey)
         // Кэшируем избранные заклинания
-        cacheManager.cacheFavorites(Array(favoriteSpells))
+        cacheManager.cacheFavoriteSpells(Array(favoriteSpells))
     }
     
     private func saveFeats() {
         UserDefaults.standard.set(Array(favoriteFeats), forKey: featsStorageKey)
         // Кэшируем избранные умения
-        cacheManager.cacheFavorites(Array(favoriteFeats))
+        cacheManager.cacheFavoriteFeats(Array(favoriteFeats))
     }
     
     private func saveBackgrounds() {
         UserDefaults.standard.set(Array(favoriteBackgrounds), forKey: backgroundsStorageKey)
         // Кэшируем избранные предыстории
-        cacheManager.cacheFavorites(Array(favoriteBackgrounds))
+        cacheManager.cacheFavoriteBackgrounds(Array(favoriteBackgrounds))
     }
     
     private func load() {
-        // Сначала пытаемся загрузить из кэша
-        if let cachedSpells = cacheManager.getCachedFavorites() {
+        // Сначала пытаемся загрузить заклинания из кэша
+        if let cachedSpells = cacheManager.getCachedFavoriteSpells() {
             favoriteSpells = Set(cachedSpells)
             print("✅ [FAVORITES] Загружено \(cachedSpells.count) избранных заклинаний из кэша")
-        } else {
-            // Если кэша нет, загружаем из UserDefaults
-            if let spellsArray = UserDefaults.standard.array(forKey: spellsStorageKey) as? [String] {
-                favoriteSpells = Set(spellsArray)
-                // Кэшируем избранные заклинания
-                cacheManager.cacheFavorites(Array(favoriteSpells))
-                print("✅ [FAVORITES] Загружено \(favoriteSpells.count) избранных заклинаний из UserDefaults и закэшировано")
-            }
+        } else if let spellsArray = UserDefaults.standard.array(forKey: spellsStorageKey) as? [String] {
+            // Если кэша нет, загружаем из UserDefaults и кэшируем
+            favoriteSpells = Set(spellsArray)
+            cacheManager.cacheFavoriteSpells(Array(favoriteSpells))
+            print("✅ [FAVORITES] Загружено \(favoriteSpells.count) избранных заклинаний из UserDefaults и закэшировано")
         }
-        
-        if let featsArray = UserDefaults.standard.array(forKey: featsStorageKey) as? [String] {
+
+        // Загружаем умения из кэша или UserDefaults
+        if let cachedFeats = cacheManager.getCachedFavoriteFeats() {
+            favoriteFeats = Set(cachedFeats)
+        } else if let featsArray = UserDefaults.standard.array(forKey: featsStorageKey) as? [String] {
             favoriteFeats = Set(featsArray)
+            cacheManager.cacheFavoriteFeats(Array(favoriteFeats))
         }
-        
-        if let backgroundsArray = UserDefaults.standard.array(forKey: backgroundsStorageKey) as? [String] {
+
+        // Загружаем предыстории из кэша или UserDefaults
+        if let cachedBackgrounds = cacheManager.getCachedFavoriteBackgrounds() {
+            favoriteBackgrounds = Set(cachedBackgrounds)
+        } else if let backgroundsArray = UserDefaults.standard.array(forKey: backgroundsStorageKey) as? [String] {
             favoriteBackgrounds = Set(backgroundsArray)
+            cacheManager.cacheFavoriteBackgrounds(Array(favoriteBackgrounds))
         }
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated cache keys for favorite spells, feats, and backgrounds
- expose cache helpers for favorites by type
- update FavoriteSpellsManager to use new cache methods and load from separate caches

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift /tmp/cache_test.swift`


------
https://chatgpt.com/codex/tasks/task_e_68a041a640ac83298f3a36dd3ab9ab33