### PR TITLE
Refactor adaptive background to return SwiftUI views directly

### DIFF
--- a/dnd_app/dnd_app/SpellsView.swift
+++ b/dnd_app/dnd_app/SpellsView.swift
@@ -14,17 +14,9 @@ struct SpellsView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(
-                colors: [
-                    Color("BackgroundColor"),
-                    Color("BackgroundColor").opacity(0.9),
-                    Color("BackgroundColor")
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .ignoresSafeArea()
-            
+            ThemeManager.adaptiveBackground(for: themeManager.preferredColorScheme)
+                .ignoresSafeArea()
+
             VStack(spacing: 0) {
                 SearchAndFilterSection(store: store, favorites: favorites, themeManager: themeManager, currentTab: 0)
                 AllSpellsTab(store: store, favorites: favorites, themeManager: themeManager)
@@ -117,16 +109,8 @@ struct SpellSearchView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                LinearGradient(
-                    colors: [
-                        Color("BackgroundColor"),
-                        Color("BackgroundColor").opacity(0.9),
-                        Color("BackgroundColor")
-                    ],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-                .ignoresSafeArea()
+                ThemeManager.adaptiveBackground(for: themeManager.preferredColorScheme)
+                    .ignoresSafeArea()
 
                 VStack(spacing: 0) {
                 // Search bar

--- a/dnd_app/dnd_app/ThemeManager.swift
+++ b/dnd_app/dnd_app/ThemeManager.swift
@@ -34,11 +34,12 @@ final class ThemeManager: ObservableObject {
     )
     
     // Адаптивные цвета
-    static func adaptiveBackground(for colorScheme: ColorScheme?) -> AnyView {
+    @ViewBuilder
+    static func adaptiveBackground(for colorScheme: ColorScheme?) -> some View {
         if colorScheme == .dark {
-            return AnyView(darkBackgroundGradient)
+            darkBackgroundGradient
         } else {
-            return AnyView(backgroundColor)
+            backgroundColor
         }
     }
 


### PR DESCRIPTION
## Summary
- Refactor `ThemeManager.adaptiveBackground` to return `some View` using a ViewBuilder
- Replace manual gradients in `SpellsView` and `SpellSearchView` with `adaptiveBackground`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a041c1e0e08329a6e111589b8f0437