### PR TITLE
Add deferred save mechanism for notes

### DIFF
--- a/dnd_app/tabaxiTests/NotesStoreSaveTests.swift
+++ b/dnd_app/tabaxiTests/NotesStoreSaveTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import tabaxi
+
+final class NotesStoreSaveTests: XCTestCase {
+    func testSaveOccursAfterDelay() {
+        UserDefaults.standard.removeObject(forKey: "notes_v1")
+        CacheManager.shared.clearCache(for: CacheManager.CacheKey.notes.rawValue)
+        let store = NotesStore()
+        let note = Note(title: "title", description: "", category: .places, importance: 1, dateCreated: Date(), dateModified: Date())
+        store.add(note)
+        XCTAssertEqual(store.saveCallCount, 0)
+        let exp = expectation(description: "wait for save")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(store.saveCallCount, 1)
+    }
+
+    func testFrequentEditsTriggerSingleSave() {
+        UserDefaults.standard.removeObject(forKey: "notes_v1")
+        CacheManager.shared.clearCache(for: CacheManager.CacheKey.notes.rawValue)
+        let store = NotesStore()
+        var note = Note(title: "title", description: "", category: .places, importance: 1, dateCreated: Date(), dateModified: Date())
+        store.add(note)
+        note.title = "updated 1"
+        store.update(note)
+        note.title = "updated 2"
+        store.update(note)
+        let exp = expectation(description: "wait for save")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(store.saveCallCount, 1)
+        XCTAssertEqual(store.notes.first?.title, "updated 2")
+    }
+}


### PR DESCRIPTION
## Summary
- add `scheduleSave` debounce to `NotesStore`
- prevent unnecessary writes and track save calls
- test delayed saving and debounced edits

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project dnd_app.xcodeproj -scheme tabaxi -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a041b3cb088329b2b17c39534e0f38